### PR TITLE
fix: check for defined proto services before considering a file for generation

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -839,6 +839,12 @@ func (g *Generator) WrapTypes() {
 		if fd == nil {
 			g.Fail("could not find file named", fileName)
 		}
+
+		// If the file has no services defined, skip it.
+		if len(fd.GetService()) == 0 {
+			continue
+		}
+
 		fd.index = len(g.genFiles)
 		g.genFiles = append(g.genFiles, fd)
 	}


### PR DESCRIPTION
fix: check for defined proto services before considering a file for generation